### PR TITLE
Fix bug report dialog to safely access window location (#26)

### DIFF
--- a/web/components/shared/report-bug/index.tsx
+++ b/web/components/shared/report-bug/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -31,6 +31,7 @@ export function BugReportDialog({
     FormData
   >(submitBugReport, null);
   const formRef = useRef<HTMLFormElement>(null);
+  const [pageUrl, setPageUrl] = useState("");
 
   useEffect(() => {
     if (state?.message) {
@@ -43,6 +44,12 @@ export function BugReportDialog({
       toast.error(state.error);
     }
   }, [state, onOpenChange]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setPageUrl(window.location.href);
+    }
+  }, []);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -57,7 +64,7 @@ export function BugReportDialog({
         </DialogHeader>
 
         <form ref={formRef} action={formAction}>
-          <input type="hidden" name="pageUrl" value={window?.location.href} />
+          <input type="hidden" name="pageUrl" value={pageUrl} />
 
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">


### PR DESCRIPTION
This pull request updates the `BugReportDialog` component in `web/components/shared/report-bug/index.tsx` to improve how the current page URL is handled when submitting bug reports. The changes ensure better compatibility and reliability by leveraging React state for managing the page URL.

### Improvements to page URL handling:

* Added `useState` to manage the `pageUrl` state and initialized it with an empty string. (`[[1]](diffhunk://#diff-e77c59ef1396e03b9c852b4a3fa86000d042cb7b664e17ca4e3f900586787734L3-R3)`, `[[2]](diffhunk://#diff-e77c59ef1396e03b9c852b4a3fa86000d042cb7b664e17ca4e3f900586787734R34)`)
* Introduced a `useEffect` hook to set the `pageUrl` state to the current page's URL using `window.location.href`. This ensures the URL is only accessed in a browser environment. (`[web/components/shared/report-bug/index.tsxR48-R53](diffhunk://#diff-e77c59ef1396e03b9c852b4a3fa86000d042cb7b664e17ca4e3f900586787734R48-R53)`)
* Updated the hidden input field in the bug report form to use the `pageUrl` state instead of directly accessing `window.location.href`. (`[web/components/shared/report-bug/index.tsxL60-R67](diffhunk://#diff-e77c59ef1396e03b9c852b4a3fa86000d042cb7b664e17ca4e3f900586787734L60-R67)`)