### PR TITLE
Add remote pattern for assets.foundersignal.app in Next.js config

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -24,6 +24,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "pub-*.r2.dev",
       },
+      {
+        protocol: "https",
+        hostname: "assets.foundersignal.app",
+      },
     ],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],


### PR DESCRIPTION
Introduce a new remote pattern for the assets.foundersignal.app domain in the Next.js configuration to enable asset handling.