### PR TITLE
Add Vercel Repo ID to deployment payload and disable push trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy and Clear Cache
 
 on:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Include the Vercel Repo ID in the deployment payload and logs for better tracking. Comment out the push trigger in the deployment workflow to prevent automatic deployments from the main branch.