### PR TITLE
Increase maximum wait time for Vercel deployment status checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,8 +93,8 @@ jobs:
           echo "Waiting 75 seconds before first status check..."
           sleep 75  # initial delay of 1 minute 15 seconds, average deployment time
 
-          MAX_WAIT=50 # Maximum wait time in seconds
-          INTERVAL=10
+          MAX_WAIT=60 # Maximum wait time in seconds
+          INTERVAL=20
           ELAPSED=0
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do


### PR DESCRIPTION
Extend the maximum wait time for deployment status checks from 30 seconds to 60 seconds to accommodate longer deployment durations.